### PR TITLE
Commented out matplotlib.use

### DIFF
--- a/svo_filters/svo.py
+++ b/svo_filters/svo.py
@@ -11,7 +11,7 @@ import astropy.io.votable as vo
 import astropy.units as q
 import astropy.constants as ac
 import matplotlib
-matplotlib.use('Agg')
+# matplotlib.use('Agg')
 import pylab as plt
 import warnings
 import pickle


### PR DESCRIPTION
This call to matplotlib.use('Agg') gives constant errors when using `SVO_filters` inside `ExoCTK`, such as with `AWESim_SOSS`.  It mandates that the user use the backend preferred by the `SVO_Filters` developers, instead of their own defaults.