### PR TITLE
Commented out line 14 to avoid redundant errors

### DIFF
--- a/svo_filters/svo.py
+++ b/svo_filters/svo.py
@@ -11,7 +11,7 @@ import astropy.io.votable as vo
 import astropy.units as q
 import astropy.constants as ac
 import matplotlib
-matplotlib.use('Agg')
+# matplotlib.use('Agg')
 import pylab as plt
 import warnings
 import pickle


### PR DESCRIPTION
changed `line 14` from `matplotlib.use('Agg')` to `# matplotlib.use('Agg')`

This use of `matplotlib.use('Agg')` assumes that this file is the first file used in an interactive mode.  If the user has a default `backend`, then this line causes redundant errors that are unnecessary.