### PR TITLE
Allow non-IndexErrors to surface to the user

### DIFF
--- a/svo_filters/svo.py
+++ b/svo_filters/svo.py
@@ -160,19 +160,21 @@ class Filter:
             # Otherwise try a Web query or throw an error
             else:
               
-                err = """No filters match {}\n\nFILTERS ON FILE: {}\n\nA full list of available filters from the\nSVO Filter Profile Service can be found at\nhttp: //svo2.cab.inta-csic.es/theory/fps3/\n\nTry again with the desired filter as '<facility>/<instrument>.<filter_name>', e.g. '2MASS/2MASS.J'""".format(band, ', '.join(bands))
+                err = f"No filters match {band}\n\nFILTERS ON FILE: \n\nFILTERS ON FILE: {', '.join(bands)}\n\n" 
+                "A full list of available filters from the\nSVO Filter Profile Service can be found at\n"
+                "http: //svo2.cab.inta-csic.es/theory/fps3/\n\nTry again with the desired filter as " 
+                "'<facility>/<instrument>.<filter_name>', e.g. '2MASS/2MASS.J'"
+
+                # Valid SVO filter names have backslash
+                if '/' not in band:
+                    raise IndexError(err)
 
                 # Try a web query
-                if '/' in band:
-                    try:
-                        self.load_web(band)
-                    except:
-                        raise IndexError(err)
-                
-                else:
-                    
-                    # Or throw an error
+                try:
+                    self.load_web(band)
+                except IndexError:
                     raise IndexError(err)
+                # Make sure we return e.g. Connection Error, but are not catching e.g. SysExit calls.
 
         # Set the wavelength and throughput
         self._wave_units = q.AA


### PR DESCRIPTION
Change generic exception catching to IndexError, so that things like connection error are reported correctly for diagnostics.

Fixes #37.


Edit: A little bit of background on this. I tested various errors and I think this is the only one we need to catch to give the prompt. But the prompt can be attached to any error as an addition if you want:

```
except Exception as e:
    e.args # modify this with prompt
    raise e
```