### PR TITLE
Replace deprecated pkg_resources with importlib.resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ for root, _, files in os.walk("svo_filters"):
 
 setup(
     name='svo_filters',
-    version='0.5.2',
+    version='0.5.3',
     description='A Python wrapper for the SVO Filter Profile Service',
     packages=find_packages(
         ".",

--- a/svo_filters/svo.py
+++ b/svo_filters/svo.py
@@ -6,7 +6,7 @@ A Python wrapper for the SVO Filter Profile Service
 from glob import glob
 import inspect
 import os
-from importlib.resources import files
+from importlib import resources
 import warnings
 import urllib.request
 import itertools
@@ -115,7 +115,7 @@ class Filter:
             to ensure montonically increasing wavelengths.
         """
         if filter_directory is None:
-            filter_directory = str(files(__package__).joinpath('data/filters/'))
+            filter_directory = str(resources.files(__package__).joinpath('data/filters/'))
 
         # Whether to ensure wavelengths returned should be strictly monotonically increasing.
         self.monotonic = monotonic 
@@ -537,7 +537,7 @@ class Filter:
         x, f = self.raw
 
         # Rebin Vega to filter
-        vega_file = str(files(__package__).joinpath('data/spectra/vega.txt'))
+        vega_file = str(resources.files(__package__).joinpath('data/spectra/vega.txt'))
         vega_data = np.genfromtxt(vega_file, unpack=True)[: 2]
         vega_data[0] *= 10000
         vega = rebin_spec(vega_data, x)
@@ -886,7 +886,7 @@ def filters(filter_directory=None):
         The list of band names
     """
     if filter_directory is None:
-        filter_directory = str(files(__package__).joinpath('data/filters/'))
+        filter_directory = str(resources.files(__package__).joinpath('data/filters/'))
 
     # Get list of files from dir
     files = glob(os.path.join(filter_directory, '*'))

--- a/svo_filters/svo.py
+++ b/svo_filters/svo.py
@@ -6,7 +6,7 @@ A Python wrapper for the SVO Filter Profile Service
 from glob import glob
 import inspect
 import os
-from pkg_resources import resource_filename
+from importlib.resources import files
 import warnings
 import urllib.request
 import itertools
@@ -115,7 +115,7 @@ class Filter:
             to ensure montonically increasing wavelengths.
         """
         if filter_directory is None:
-            filter_directory = resource_filename('svo_filters', 'data/filters/')
+            filter_directory = str(files(__package__).joinpath('data/filters/'))
 
         # Whether to ensure wavelengths returned should be strictly monotonically increasing.
         self.monotonic = monotonic 
@@ -537,7 +537,7 @@ class Filter:
         x, f = self.raw
 
         # Rebin Vega to filter
-        vega_file = resource_filename('svo_filters', 'data/spectra/vega.txt')
+        vega_file = str(files(__package__).joinpath('data/spectra/vega.txt'))
         vega_data = np.genfromtxt(vega_file, unpack=True)[: 2]
         vega_data[0] *= 10000
         vega = rebin_spec(vega_data, x)
@@ -886,7 +886,7 @@ def filters(filter_directory=None):
         The list of band names
     """
     if filter_directory is None:
-        filter_directory = resource_filename('svo_filters', 'data/filters/')
+        filter_directory = str(files(__package__).joinpath('data/filters/'))
 
     # Get list of files from dir
     files = glob(os.path.join(filter_directory, '*'))


### PR DESCRIPTION
This resolves a deprecation warning related to pkg_resources.resource_filename, which was slated for removal in late 2025. All uses were replaced with the modern importlib.resources.files() API. This change requires Python 3.9+.

In particular, the previous warning message was:
```
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```